### PR TITLE
add multiple ssh keys to compute instance

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "google_compute_instance" "host" {
     /* This is a hack because we can't use dots in actual instance name */
     hostname = local.hostnames[count.index]
     /* Enable SSH access */
-    sshKeys = "${var.ssh_user}:${file(var.ssh_key)}"
+    ssh-keys = join("\n", [for key in var.ssh_keys : "root:${key}"])
     /* Run PowerShell script for initial setup of a Window machine */
     sysprep-specialize-script-ps1 = (var.win_password == null ? null :
       templatefile("${path.module}/setup.ps1", {

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "google_compute_instance" "host" {
     /* This is a hack because we can't use dots in actual instance name */
     hostname = local.hostnames[count.index]
     /* Enable SSH access */
-    ssh-keys = join("\n", [for key in var.ssh_keys : "root:${key}"])
+    ssh-keys = join("\n", [for key in var.ssh_keys : "${var.ssh_user}:${key}"])
     /* Run PowerShell script for initial setup of a Window machine */
     sysprep-specialize-script-ps1 = (var.win_password == null ? null :
       templatefile("${path.module}/setup.ps1", {

--- a/variables.tf
+++ b/variables.tf
@@ -111,10 +111,13 @@ variable "ssh_user" {
   default     = "root"
 }
 
-variable "ssh_key" {
-  description = "Names of ssh public keys to add to created hosts"
-  type        = string
-  default     = "~/.ssh/status.im/id_rsa.pub" /* TODO this needs to be dynamic */
+variable "ssh_keys" {
+  description = "Names of ssh public keys to add to root user of created hosts"
+  type        = list(string)
+  default = [
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDA6mutbRHO8VvZ61MYvjIVv1Re9NiJGE1piTQq4IFwXOvAi1HkXkMlsjmzYt+CEv0HmMGCHmdrw5xpqnDTWg18lM5RYLzrAv9hBOQ10IC+8FH2XWDKoyz+PBQsNEbbJ23QQtu0O5mpsOzI/KBT9CkiYUYlEBwHI0vNqsdHDLwv3Yt7PhauguXDHpYnwH/OseVHLBg2+/3aJIfOMVVRnhptQGYAhTNUZ9F1EwvQETMhM/vEsk8+o9B3tK/Ii/RD2EtVUlpRG4q6QTFbssLMImUfcdoggHsfCqjq3apUs8bR81oN9UVoYiP8tn5sWIUyRBxIEzXpqa4rx04KY8xNYqeZ jakub@status.im",
+    "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQCrYtuXQi7TkyGVsXtd81LyOLihMHpZFZnArrNn8m90lOmohSwD8pSgX+Lhw+yEguSgnBhYIDWxDzZqGHIMXquCwwK6Kv4RT+IpwX9m5yMUJbReLAe5NbjX3thGkd9+wHFqpHnO7bzLuKeNqyYdm6I8/l3e4P6fG7NOvDReSX4lNoSZpOJD9pmzxH1rv4kI/NfKxhm88rpZ2D6Nx2k9Eep3KjVYTIUFTre98eoV/4USrAB0Mj8nHqA/i0nTni2pf8rBYp0xlLik91+k2skLrHgfUi4LuzEkudGYZPdDSC1qrsB6qjmO0z6lEyYIUpr9My7vANKT9MT5VKsNJomATChlD1x3THjW++2aQ+XXHYkmTqKixPzJiB1D8SWBKnEI1wjKadv2J8RuTBPeybtBfuY3Mqj9U2xrp7Rr3l/ciiSk+z2v3HGW4XFtaMpmOc69sghE9nu+0lEEkA7o+Xlml2PUdPfFPmO3G1PRcK9v/Fyz6BPMZhaDCiENS6IhapsuNAUiEp8FriocAInd/UKlJyH+ydZ9d/ivQ3XaMuOr6AOpbwO+MZEPEGJG051+SFyXUWaN6xWQx2cAgSgF4yjbZpeIfkOoOdIu9BDmCR3rD0L4W4RxBTop8OJ+eZaGNvdk8T0Ty5/tlxmL1tKjktlPjMFv2Nr/laTmUyLuKefQlW1Y4w== arthur@status.im"
+  ]
 }
 
 variable "win_password" {


### PR DESCRIPTION
The current setup uses the content of `~/.ssh/status.im/id_rsa.pub` as the compute instance ssh key, which leads to the instance metadata being changed every time terraform is run by a different user. With this setup we have the keys (currently Jakub and me) hardcoded.